### PR TITLE
Spotify lib update

### DIFF
--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -1,8 +1,6 @@
-import querystring from 'querystring'
-
-const client_id = process.env.SPOTIFY_CLIENT_ID;
-const client_secret = process.env.SPOTIFY_CLIENT_SECRET
-const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN;
+const client_id = process.env.SPOTIFY_CLIENT_ID || '';
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET || '';
+const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN || '';
 
 const basic = Buffer.from(`${client_id}:${client_secret}`).toString("base64");
 const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`
@@ -16,7 +14,7 @@ const getAccessToken = async () => {
             Authorization: `Basic ${basic}`,
             'Content-Type': 'application/x-www-form-urlencoded'
         },
-        body: querystring.stringify({
+        body: new URLSearchParams({
             grant_type: 'refresh_token',
             refresh_token
         })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,12 +1,3 @@
-export type SpotifyNowPlayingSong = {
-    isPlaying: boolean;
-    title: string;
-    artist: string;
-    album: string;
-    albumImageUrl: string;
-    songUrl: string;
-}
-
 export type SpotifySong = {
     title: string;
     artist: string;
@@ -14,6 +5,10 @@ export type SpotifySong = {
     albumImageUrl: string;
     songUrl: string;
 };
+
+export type SpotifyNowPlayingSong = SpotifySong & {
+    isPlaying: boolean;
+}
 
 export type SpotifyTopTracks = {
     tracks: SpotifySong[];


### PR DESCRIPTION
- Removed `querystring` as it's considered legacy in favor of `URLSearchParams`.
- Extended type to avoid code duplication.